### PR TITLE
[2.6] Fix securityGroups Incorrect reverse display and Update docker installation URL

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -482,19 +482,24 @@ export default Ember.Component.extend(NodeDriver, {
       }
 
       securityGroupsPromise.then((securityGroups) => {
-        set(this, 'securityGroups', securityGroups.map((securityGroup) => {
-          let label = `${ securityGroup.raw.SecurityGroupName } (${ securityGroup.value })`
+        const out = [];
 
-          return {
-            ...securityGroup,
-            value: securityGroup.raw.SecurityGroupName,
+        securityGroups.forEach(obj=>{
+          const label = `${ obj.raw.SecurityGroupName } (${ obj.value })`;
+
+          out.push({
+            ...obj,
+            value: obj.raw.SecurityGroupName,
             label
-          };
-        }));
+          })
+        });
+
+        set(this, 'securityGroups', out);
+
         const selectedSecurityGroup = get(this, 'config.securityGroup');
 
         if (selectedSecurityGroup) {
-          const found = securityGroups.findBy('value', selectedSecurityGroup);
+          const found = out.findBy('value', selectedSecurityGroup);
 
           if (!found) {
             set(this, 'config.securityGroup', 'docker-machine');

--- a/component/component.js
+++ b/component/component.js
@@ -136,7 +136,7 @@ export default Ember.Component.extend(NodeDriver, {
         spotStrategy:         'SpotAsPriceGo',
       });
 
-      set(this, 'model.engineInstallURL', 'https://drivers.rancher.cn/pandaria/docker-install/19.03-aliyun.sh');
+      set(this, 'model.engineInstallURL', 'https://rancher2-drivers.oss-cn-beijing.aliyuncs.com/pandaria/docker-install/19.03-aliyun.sh');
       set(this,'model.engineStorageDriver', 'overlay2');
       set(this, 'model.%%DRIVERNAME%%Config', config);
     } else {


### PR DESCRIPTION
1. 修复安全组反显错误问题
2. 更新引擎选项中 docker 安装 URL
3. 系统镜像根据rancher支持矩阵进行过滤和排序

https://github.com/cnrancher/pandaria/issues/2409